### PR TITLE
Fix unique ID generation in url shortener

### DIFF
--- a/url-shortener/src/urls/url.service.ts
+++ b/url-shortener/src/urls/url.service.ts
@@ -12,11 +12,13 @@ import {nanoid} from "nanoid";
  */
 const generateUniqueId = async () => {
   let shortUrl = nanoid(8);
-  let existingShortUrl = await Url.find({shortUrl});
+  let existingShortUrl = await Url.findOne({ shortUrl });
+
   while (existingShortUrl) {
     shortUrl = nanoid(8);
-    existingShortUrl = await Url.find({shortUrl});
+    existingShortUrl = await Url.findOne({ shortUrl });
   }
+
   return shortUrl;
 }
 


### PR DESCRIPTION
## Summary
- prevent infinite loop by using `findOne` when generating unique short URLs

## Testing
- `npm test` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_684687e65488832b9259a68373e80d79