### PR TITLE
Fix .envExample formatting

### DIFF
--- a/job-board-api/.envExample
+++ b/job-board-api/.envExample
@@ -1,6 +1,6 @@
 MONGODB_URL=YourMongoDbURL
 NODE_ENV=developmentOrproduction
-PORT=YourPortDefaultIs4000`
+PORT=YourPortDefaultIs4000
 JWT_SECRET=JWTSecret
 JWT_EXPIRE_IN_MINUTE=JWT_SECRET_IN_MINUTE
 CLOUDINARY_NAME=your Cloud Name

--- a/url-shortener/.envExample
+++ b/url-shortener/.envExample
@@ -1,3 +1,3 @@
 MONGODB_URL=YourMongoDbURL
 NODE_ENV=developmentOrproduction
-PORT=YourPortDefaultIs4000`
+PORT=YourPortDefaultIs4000


### PR DESCRIPTION
## Summary
- remove stray backticks in env example files
- ensure each env example ends with a newline

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68468b485128832b86eded10f14c55aa